### PR TITLE
Issue291/pkg resources

### DIFF
--- a/requirements-docs.txt
+++ b/requirements-docs.txt
@@ -1,5 +1,5 @@
 -e .
-sphinx==1.6.3
-numpydoc==0.6.0
+sphinx==7.2.6
+numpydoc==1.6.0
 psycopg2-binary==2.9.1
 jinja2<3.1.0

--- a/sqlalchemy_redshift/__init__.py
+++ b/sqlalchemy_redshift/__init__.py
@@ -2,7 +2,6 @@ from importlib.metadata import distribution as get_distribution
 from importlib.metadata import version
 
 from packaging.version import parse as parse_version
-from pkg_resources import get_distribution
 
 for package in ['psycopg2', 'psycopg2-binary', 'psycopg2cffi']:
     try:

--- a/sqlalchemy_redshift/__init__.py
+++ b/sqlalchemy_redshift/__init__.py
@@ -1,14 +1,19 @@
-from pkg_resources import DistributionNotFound, get_distribution, parse_version
+from importlib.metadata import distribution as get_distribution
+from importlib.metadata import version
+
+from packaging.version import parse as parse_version
+from pkg_resources import get_distribution
 
 for package in ['psycopg2', 'psycopg2-binary', 'psycopg2cffi']:
     try:
-        if get_distribution(package).parsed_version < parse_version('2.5'):
+        package_version = version(package)
+        if parse_version(package_version) < parse_version('2.5'):
             raise ImportError('Minimum required version for psycopg2 is 2.5')
         break
-    except DistributionNotFound:
+    except ModuleNotFoundError:
         pass
 
-__version__ = get_distribution('sqlalchemy-redshift').version
+__version__ = get_distribution('sqlalchemy_redshift').version
 
 from sqlalchemy.dialects import registry  # noqa
 

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -3,8 +3,8 @@ import json
 import re
 from collections import defaultdict, namedtuple
 from logging import getLogger
+from pathlib import Path
 
-import pkg_resources
 import sqlalchemy as sa
 from packaging.version import Version
 from sqlalchemy import inspect
@@ -1210,12 +1210,10 @@ class Psycopg2RedshiftDialectMixin(RedshiftDialectMixin):
         Overrides interface
         :meth:`~sqlalchemy.engine.interfaces.Dialect.create_connect_args`.
         """
+        cwd = Path(__file__).parent.resolve()
         default_args = {
             'sslmode': 'verify-full',
-            'sslrootcert': pkg_resources.resource_filename(
-                __name__,
-                'redshift-ca-bundle.crt'
-            ),
+            'sslrootcert': str(cwd / 'redshift-ca-bundle.crt'),
         }
         cargs, cparams = (
             super(Psycopg2RedshiftDialectMixin, self).create_connect_args(

--- a/tests/test_default_ssl.py
+++ b/tests/test_default_ssl.py
@@ -1,11 +1,15 @@
+from pathlib import Path
+
 import sqlalchemy as sa
-from pkg_resources import resource_filename
 from sqlalchemy_redshift.dialect import (
     Psycopg2RedshiftDialectMixin, RedshiftDialect_redshift_connector
 )
 
 
-CERT_PATH = resource_filename("sqlalchemy_redshift", "redshift-ca-bundle.crt")
+cwd = Path(__file__).parent.resolve()
+sqlalchemy_redshift_dir = cwd.joinpath("..") / "sqlalchemy_redshift"
+sqlalchemy_redshift_dir = sqlalchemy_redshift_dir.resolve()
+CERT_PATH = str(sqlalchemy_redshift_dir / "redshift-ca-bundle.crt")
 
 
 def test_ssl_args(redshift_dialect_flavor):


### PR DESCRIPTION
This commit removes pkg_resources requirements as they are deprecated with more recent versions of Python.

`importlib.metadata.distribution` is used in place of `pkg_resources.get_distribution`
`importlib.metadata.version` is used in place of `pkg_resources.version`
`ModuleNotFoundError` is used instead of `pkg_resources.DistributionNotFound`

## Todos
- [ ] MIT compatible
- [ ] Tests
- [ ] Documentation
- [ ] Updated CHANGES.rst

Port of https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/294