### PR TITLE
External table fix

### DIFF
--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -814,7 +814,28 @@ class RedshiftDialectMixin(DefaultDialect):
 
             return result.scalar()
         except Exception as e:
-            if "Operation not supported on external tables" in str(e):
+            # Gracefully handle external tables
+            schema_filter = (
+                "AND schemaname = '{schema}'".format(schema=schema)
+                if schema else ""
+            )
+            result = connection.execute(
+                sa.text(
+                    """
+                    SELECT
+                        1
+                    FROM svv_external_tables
+                    WHERE
+                        tablename = '{table_name}'
+                        {schema_filter}
+                    LIMIT 1;
+                    """.format(
+                        schema_filter=schema_filter,
+                        table_name=table_name
+                    )
+                )
+            )
+            if result.scalar() is not None:
                 return None
             raise e
 

--- a/sqlalchemy_redshift/dialect.py
+++ b/sqlalchemy_redshift/dialect.py
@@ -797,21 +797,26 @@ class RedshiftDialectMixin(DefaultDialect):
     @reflection.cache
     def get_table_oid(self, connection, table_name, schema=None, **kw):
         """Fetch the oid for schema.table_name.
-        Return null if not found (external table does not have table oid)"""
+        Return None if not found (external table does not have table oid)"""
         schema_field = '{schema}.'.format(schema=schema) if schema else ""
 
-        result = connection.execute(
-            sa.text(
-                """
-                select '{schema_field}{table_name}'::regclass::oid;
-                """.format(
-                    schema_field=schema_field,
-                    table_name=table_name
+        try:
+            result = connection.execute(
+                sa.text(
+                    """
+                    select '{schema_field}{table_name}'::regclass::oid;
+                    """.format(
+                        schema_field=schema_field,
+                        table_name=table_name
+                    )
                 )
             )
-        )
 
-        return result.scalar()
+            return result.scalar()
+        except Exception as e:
+            if "Operation not supported on external tables" in str(e):
+                return None
+            raise e
 
     @reflection.cache
     def get_pk_constraint(self, connection, table_name, schema=None, **kw):


### PR DESCRIPTION
Fixes #304

I'm not sure if this is the best way to solve this. I thought about checking the specific `exception` class, but got stuck on two issues:
 
* We would have to handle both the exception raised by `psycopg2` and `redshift-connector`.
* Given this dialect is supposed to work agnostically with both, we typically wouldn't import these exceptions.

Another approach would be to check the the class name. Something like:
 
```python
if (
    type(e).__name__ == 'NotSupportedError'
    or type(e).__name__ == 'ProgrammingError'
):
```
 
Or check the exception text:
 
```python
if "Operation not supported on external tables" in str(e):
```
 
But these could still be too generic. The suggested approach confirms if the table is indeed external through the metadata -- counterpart is that it executes another query.
 
Open to suggestions here. :) Once we define on next steps I can look at adding tests/etc.


Port of: https://github.com/sqlalchemy-redshift/sqlalchemy-redshift/pull/305